### PR TITLE
Nim 1.2 isn't current anymore, and `--styleCheck:error` is generally feasible

### DIFF
--- a/src/formatting.naming.md
+++ b/src/formatting.naming.md
@@ -2,7 +2,7 @@
 
 Always use the same identifier style (case, underscores) as the declaration.
 
-Enable `--styleCheck:usages`.
+Enable `--styleCheck:usages`, and, where feasible, `--styleCheck:error`.
 
 * `Ref` for `ref object` types, which have surprising semantics
   * `type XxxRef = ref Xxx`

--- a/src/formatting.style.md
+++ b/src/formatting.style.md
@@ -22,8 +22,8 @@ func someLongFunctinName(
 
 ### Practical notes
 
-* We do not use `nimpretty` - as of writing (nim 1.2), it is not stable enough for daily use:
+* We do not use `nimpretty` - as of writing (Nim 1.6), it is not stable enough for daily use:
     * Can break working code
     * Naive formatting algorithm
 * We do not make use of Nim's "flexible" identifier names - all uses of an identifier should match the declaration in capitalization and underscores
-    * Enable `--styleCheck:usages`
+    * Enable `--styleCheck:usages` and, where feasible, `--styleCheck:error`


### PR DESCRIPTION
`nimbus-eth2` has difficulty using `styleCheck:error` essentially because EL and CL specs use different but sufficiently similar naming conventions to trip it, but most other Status repositories probably can use it, and many already do.

`nimpretty` is still not safe to use: https://github.com/nim-lang/Nim/issues/12651 https://github.com/nim-lang/Nim/issues/12927 https://github.com/nim-lang/Nim/issues/18498 https://github.com/nim-lang/Nim/issues/20078 https://github.com/nim-lang/Nim/issues/21018 etc.