### PR TITLE
Update link to vscode nim plugin

### DIFF
--- a/src/tooling.editors.md
+++ b/src/tooling.editors.md
@@ -4,7 +4,7 @@
 
 Most `nim` developers use `vscode`.
 
-* [Nim Extension](https://marketplace.visualstudio.com/items?itemName=nimsaem.nimvscode) gets you syntax highlighting, goto definition and other modernities
+* [Nim Extension](https://marketplace.visualstudio.com/items?itemName=NimLang.nimlang) gets you syntax highlighting, goto definition and other modernities
   * The older, but less maintained [Nim plugin](https://marketplace.visualstudio.com/items?itemName=kosz78.nim) is an alternative
 * To start `vscode` with the correct Nim compiler, run it with `./env.sh code`
 * Run nim files with `F6`


### PR DESCRIPTION
Updating the link to the Nim vscode extension to point to the official version which has the most recent updates. I believe this is the one to use.