### PR TITLE
chore: instructing to use --nimMainPrefix in libraries

### DIFF
--- a/src/interop.md
+++ b/src/interop.md
@@ -93,7 +93,7 @@ proc exportedFunction {.exported.} =
 ```
 
 When creating a Nim library, it should be compiled with the flag `--nimMainPrefix:your_prefix`. This changes the generated `NimMain()` function to `your_prefixNimMain()`, ensuring that its runtime initialization won’t conflict with other Nim libraries or applications.
-Then, proceed to use `your_prefixNimMain()` intead of `NimMain()` to initialize your library.
+Then, proceed to use `your_prefixNimMain()` intead of `NimMain()` to initialize your library's Nim runtime.
 
 In languages such as [Go](./interop.go.md), it is hard to anticipate which thread code will be called from - in such cases, you can safely initialize the garbage collector in every exported function instead:
 

--- a/src/interop.md
+++ b/src/interop.md
@@ -92,6 +92,9 @@ proc exportedFunction {.exported.} =
   echo "Hello from Nim
 ```
 
+When creating a Nim library, it should be compiled with the flag `--nimMainPrefix:your_prefix`. This changes the generated `NimMain()` function to `your_prefixNimMain()`, ensuring that its runtime initialization won’t conflict with other Nim libraries or applications.
+Then, proceed to use `your_prefixNimMain()` intead of `NimMain()` to initialize your library.
+
 In languages such as [Go](./interop.go.md), it is hard to anticipate which thread code will be called from - in such cases, you can safely initialize the garbage collector in every exported function instead:
 
 ```nim


### PR DESCRIPTION
Adding instructions to use `--nimMainPrefix` in Nim libraries to avoid conflicts with other Nim libraries or applications