### PR TITLE
New recommendation for `except:`

### DIFF
--- a/src/errors.result.md
+++ b/src/errors.result.md
@@ -14,7 +14,7 @@ Isolate legacy code with explicit exception handling, converting the errors to `
 
 ```nim
 # Enable exception tracking for all functions in this module
-{.push raises: [].} # Always at start of module
+{.push raises: [], gcsafe.} # Always at start of module
 
 import results
 export results # Re-export modules used in public symbols


### PR DESCRIPTION
Following the acceptance of https://github.com/nim-lang/RFCs/issues/557, `except:` now has mostly well-defined behavior.

Also add `gcsafe` to `push` recommendation which improves error messages overall.