### PR TITLE
Recommend `nph` for formatting

### DIFF
--- a/src/formatting.md
+++ b/src/formatting.md
@@ -1,1 +1,8 @@
 # Formatting
+
+Projects are recommended to use [`nph`](https://github.com/arnetheduck/nph) for formatting source code and to verify this is follwed [in CI](https://github.com/arnetheduck/nph-action) using a pinned `nph` version.
+
+## Tips
+
+* Avoid changing the formatting of unrelated surrounding code
+* Libraries and projects may not all use the same `nph` version - check that the formatter has not made a mess

--- a/src/formatting.style.md
+++ b/src/formatting.style.md
@@ -9,21 +9,23 @@ We strive to follow [NEP-1](https://nim-lang.org/docs/nep1.html) for style matte
 * Small differences due to manual formatting
 * Aligned indents - we prefer python-style hanging indent for in multiline code
     * This is to avoid realignments when changes occur on the first line. The extra level of indentation is there to clearly distinguish itself as a continuation line.
+* Line length limit
+  * `nph` uses an [88-character](https://arnetheduck.github.io/nph/faq.html#why-88-characters) line width which results in the occasional line exceeding the usual 80-character limit
 
-```
+```nim
 func someLongFunctinName(
-    alsoLongVariableName: int) = # Double-indent
+    alsoLongVariableName: int # Hanging double indent
+) =
   discard # back to normal indent
 
   if someLongCondition and
-      moreLongConditions: # Double-indent
+      moreLongConditions: # Hanging double indent
     discard # back to normal indent
 ```
 
 ### Practical notes
 
-* We do not use `nimpretty` - as of writing (Nim 2.0), it is not stable enough for daily use:
-    * Can break working code
-    * Naive formatting algorithm
+* We do not use `nimpretty` - as of writing (Nim 2.0), it is not stable enough for daily use
+  * Use [nph](./formatting.md) instead!
 * We do not make use of Nim's "flexible" identifier names - all uses of an identifier should match the declaration in capitalization and underscores
     * Enable `--styleCheck:usages` and, where feasible, `--styleCheck:error`

--- a/src/tooling.editors.md
+++ b/src/tooling.editors.md
@@ -5,6 +5,7 @@
 Most `nim` developers use `vscode`.
 
 * [Nim Extension](https://marketplace.visualstudio.com/items?itemName=NimLang.nimlang) gets you syntax highlighting, goto definition and other modernities
+  * Supports automatic formatting via [nph](github.com/arnetheduck/nph)
 * To start `vscode` with the correct Nim compiler, run it with `./env.sh code`
 * Run nim files with `F6`
 * Suggestions, goto and similar features mostly work, but sometimes hang

--- a/src/tooling.profiling.md
+++ b/src/tooling.profiling.md
@@ -7,7 +7,7 @@
 When profiling, make sure to compile your code with:
 * `-d:release` to turn on optimizations
 * `-d:lto` to enable LTO which significantly helps Nim in general
-* `--debugger:native` to enable native debug signals
+* `--debugger:native` to enable native debug symbols
 * [libbacktrace](https://github.com/status-im/nim-libbacktrace)
   * the stack trace algorithm that comes with nim is too slow for practical use
   * `--stacktrace:off` as an alternative

--- a/src/tooling.profiling.md
+++ b/src/tooling.profiling.md
@@ -8,6 +8,6 @@ When profiling, make sure to compile your code with:
 * `-d:release` to turn on optimizations
 * `-d:lto` to enable LTO which significantly helps Nim in general
 * `--debugger:native` to enable native debug symbols
-* [libbacktrace](https://github.com/status-im/nim-libbacktrace)
+* Incorporate [libbacktrace](https://github.com/status-im/nim-libbacktrace) or disable stack traces
   * the stack trace algorithm that comes with nim is too slow for practical use
   * `--stacktrace:off` as an alternative

--- a/src/tooling.profiling.md
+++ b/src/tooling.profiling.md
@@ -2,3 +2,12 @@
 
 * Linux: `perf`
 * Anywhere: [vtune](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/vtune-profiler.html)
+
+
+When profiling, make sure to compile your code with:
+* `-d:release` to turn on optimizations
+* `-d:lto` to enable LTO which significantly helps Nim in general
+* `--debugger:native` to enable native debug signals
+* [libbacktrace](https://github.com/status-im/nim-libbacktrace)
+  * the stack trace algorithm that comes with nim is too slow for practical use
+  * `--stacktrace:off` as an alternative


### PR DESCRIPTION
Many of our projects and libraries now use
[`nph`](https://github.com/arnetheduck/nph) which helps reduce style noise in PRs.