### PR TITLE
`return` guidelines

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -17,6 +17,7 @@
   - [Methods](language.methods.md)
   - [`proc` types](language.proctypes.md)
   - [`result` return](language.result.md)
+  - [`return` keyword](language.return.md)
   - [`inline`](language.inline.md)
   - [Converters](language.converters.md)
   - [Finalizers](language.finalizers.md)

--- a/src/language.refobject.md
+++ b/src/language.refobject.md
@@ -14,7 +14,8 @@ Prefer explicit `ref MyType` where reference semantics are needed, allowing the 
 func f(v: ref Xxx) = discard
 let x: ref Xxx = new Xxx
 
-# Consider using Hungarian naming convention with `ref object` - this makes it clear at usage sites that the type follows the unusual `ref` semantics
+# Consider using Hungarian naming convention with `ref object` - this makes it
+# clear at usage sites that the type follows the unusual `ref` semantics
 type XxxRef = ref object
   # ...
 ```

--- a/src/language.refobject.md
+++ b/src/language.refobject.md
@@ -7,15 +7,14 @@ Avoid `ref object` types, except:
 * in reference-based data structures (trees, linked lists)
 * where a stable pointer is needed for 3rd-party compatibility
 
-Prefer explicit `ref MyType` where reference semantics are needed, allowing the caller to choose where possible.
+Prefer explicit `ref MyType` where reference semantics are needed locally and explicitly dereference with `[]`.
 
 ```nim
 # prefer explicit ref modifiers at usage site
 func f(v: ref Xxx) = discard
 let x: ref Xxx = new Xxx
 
-# Consider using Hungarian naming convention with `ref object` - this makes it
-# clear at usage sites that the type follows the unusual `ref` semantics
+# Use a `Ref` suffix in the type name to convey `ref object` semantics
 type XxxRef = ref object
   # ...
 ```
@@ -40,3 +39,5 @@ type XxxRef = ref object
 ### Notes
 
 `XxxRef = ref object` is a syntactic shortcut that hides the more explicit `ref Xxx` where the type is used - by explicitly spelling out `ref`, readers of the code become aware of the alternative reference / shared ownership semantics, which generally allows a deeper understanding of the code without having to look up the type declaration.
+
+`XxxObj` is sometimes used to refer to the non-`ref` version of a `ref object` type, specially when that type has no `Ref` suffix.

--- a/src/language.result.md
+++ b/src/language.result.md
@@ -2,7 +2,7 @@
 
 Avoid using `result` for returning values.
 
-Use expression-based return or explicit `return` keyword with a value
+Prefer expression-based return or in some cases, explicit [`return`](./language.return.md)
 
 ### Pros
 
@@ -32,11 +32,11 @@ Of the three:
 
 * "expression" returns guarantee that all code branches produce one (and only one) value to be returned
   * Used mainly when exit points are balanced and not deeply nested
-* Explict `return` with a value make explicit what value is being returned in each branch
+* Explicit `return` can simplify conditional expressions
   * Used to avoid deep nesting and early exit, above all when returning early due to errors
 * `result` is used to accumulate / build up return value, allowing it to take on invalid values in the interim
+* the usage of `result` is sometimes necessary to aid the compiler in Return-Value-Optimization analysis - if this is the case, use `result` but report a bug
 
 Multiple security issues, `nil` reference crashes and wrong-init-order issues have been linked to the use of `result` and lack of assignment in branches.
 
-In general, the use of accumulation-style initialization is discouraged unless made necessary by the data type - see [Variable initialization](language.varinit.md)
-
+In general, the use of accumulation-style initialization is discouraged unless made necessary by the data type - see [Variable initialization](language.varinit.md) - this also applies to the implict `result` variable.

--- a/src/language.return.md
+++ b/src/language.return.md
@@ -1,0 +1,40 @@
+## `return` keyword `[language.return]`
+
+Use `return` for returning early from a function, for example to reduce nesting.
+
+In other cases, prefer implicit expressions.
+
+```nim
+func f(v: ref Xxx): int =
+  if v == nil:
+    # early return to reduce nesting of happy case
+    return 0
+  ...
+
+  # However, if we're at the end of the function, prefer implicit expressions
+  if conditions:
+    v[].value # avoid `return` in complex control flow, like here where else exists
+  else:
+    0
+
+func short(): int =
+  42 # avoid `return` for last expression
+```
+
+### Pros
+
+* Explicitly shows where return happens
+* Can simplify complex conditions and nesting
+
+### Cons
+
+* Can be confused with an early return, when used at the end of a function
+* When nested deeply in control flow, can make conditions for early return difficult to understand
+
+### Practical notes
+
+* beware of `return` in `template`s since the `return` happens after template expansion!
+  * ...specially when changing a `proc` _to_ a `template`
+* `return` deep inside a complex set of conditionals indicates that the function likely needs refactoring
+* `return` of a `var` risks returning instances that have not been fully initialized - this in particular applies to the implicit [`result`](./language.result.md) variable.
+* expression style forces each branch of control-flow statements to end in a value, proving a compiler-enforced safety net that typically results in better error messages than `return`, specially when maintaining existing code

--- a/src/language.return.md
+++ b/src/language.return.md
@@ -34,7 +34,7 @@ func short(): int =
 ### Practical notes
 
 * beware of `return` in `template`s since the `return` happens after template expansion!
-  * ...specially when changing a `proc` _to_ a `template`
+  * ...especially when changing a `proc` _to_ a `template`
 * `return` deep inside a complex set of conditionals indicates that the function likely needs refactoring
 * `return` of a `var` risks returning instances that have not been fully initialized - this in particular applies to the implicit [`result`](./language.result.md) variable.
 * expression style forces each branch of control-flow statements to end in a value, proving a compiler-enforced safety net that typically results in better error messages than `return`, specially when maintaining existing code

--- a/src/language.return.md
+++ b/src/language.return.md
@@ -37,4 +37,4 @@ func short(): int =
   * ...specially when changing a `proc` _to_ a `template`
 * `return` deep inside a complex set of conditionals indicates that the function likely needs refactoring
 * `return` of a `var` risks returning instances that have not been fully initialized - this in particular applies to the implicit [`result`](./language.result.md) variable.
-* expression style forces each branch of control-flow statements to end in a value, proving a compiler-enforced safety net that typically results in better error messages than `return`, specially when maintaining existing code
+* expression style forces each branch of control-flow statements to end in a value, proving a compiler-enforced safety net increasing robustness during refactoring

--- a/src/language.return.md
+++ b/src/language.return.md
@@ -2,7 +2,7 @@
 
 Use `return` for returning early from a function, for example to reduce nesting.
 
-In other cases, prefer implicit expressions.
+In other cases, prefer implicit return expressions.
 
 ```nim
 func f(v: ref Xxx): int =
@@ -11,7 +11,7 @@ func f(v: ref Xxx): int =
     return 0
   ...
 
-  # However, if we're at the end of the function, prefer implicit expressions
+  # However, if we're at the end of the function, prefer implicit return expressions
   if conditions:
     v[].value # avoid `return` in complex control flow, like here where else exists
   else:
@@ -28,7 +28,7 @@ func short(): int =
 
 ### Cons
 
-* Can be confused with an early return, when used at the end of a function
+* Brittle during refactoring since it's easy to indent into an early return and leave the end of the function dangling
 * When nested deeply in control flow, can make conditions for early return difficult to understand
 
 ### Practical notes

--- a/src/language.return.md
+++ b/src/language.return.md
@@ -11,30 +11,32 @@ func f(v: ref Xxx): int =
     return 0
   ...
 
-  # However, if we're at the end of the function, prefer implicit return expressions
+  # Prefer implicit return expressions in most other cases
   if conditions:
-    v[].value # avoid `return` in complex control flow, like here where else exists
+    v[].value
   else:
     0
 
 func short(): int =
-  42 # avoid `return` for last expression
+  42 # simple expressions also qualify
 ```
 
 ### Pros
 
-* Explicitly shows where return happens
 * Can simplify complex conditions and nesting
+* Explicitly shows where return control flow hapens
 
 ### Cons
 
-* Brittle during refactoring since it's easy to indent into an early return and leave the end of the function dangling
-* When nested deeply in control flow, can make conditions for early return difficult to understand
+* Brittle due to lack of compile-time enforcement of exhaustiveness of control flow and initialization
+* When nested deeply, can make conditions for early return difficult to understand
+* Surprising semantics in templates and macros
 
 ### Practical notes
 
 * beware of `return` in `template`s since the `return` happens after template expansion!
   * ...especially when changing a `proc` _to_ a `template`
 * `return` deep inside a complex set of conditionals indicates that the function likely needs refactoring
-* `return` of a `var` risks returning instances that have not been fully initialized - this in particular applies to the implicit [`result`](./language.result.md) variable.
-* expression style forces each branch of control-flow statements to end in a value, proving a compiler-enforced safety net increasing robustness during refactoring
+* `return` of a `var` risks returning instances that have not been fully initialized
+  * this in particular applies to the implicit [`result`](./language.result.md) variable.
+* `return expr` is shorthand for `result = expr; return result` - this reduces to `return result` when there is no expression


### PR DESCRIPTION
Though present in other parts of the guide, this change spells out the preference for implicit returns more clearly with respect to the return keyword.

In general, we prefer expressions throughout which helps with maintenance due to the stricter compile-time checking that Nim performs - this spills over to a preference for usage of implicit expression "return" without an explicit `return` keyword at the end.