### PR TITLE
update Nim version references to 2.2

### DIFF
--- a/src/00_introduction.md
+++ b/src/00_introduction.md
@@ -28,9 +28,9 @@ When in doubt:
 
 The latest version of this book can be found [online](https://status-im.github.io/nim-style-guide/) or on [GitHub](https://github.com/status-im/nim-style-guide/).
 
-This guide currently targets Nim v2.0.
+This guide currently targets Nim v2.2.
 
-At the time of writing, v2.0 has been released but its new garbage collector is not yet stable enough for production use. It is advisable to test new code with both `--mm:refc` and `--mm:orc` (the default) in the transition period.
+At the time of writing, v2.2 has been released but its new garbage collector is not yet stable enough for production use. It is advisable to test new code with both `--mm:refc` and `--mm:orc` (the default) in the transition period.
 
 <!-- toc -->
 

--- a/src/formatting.style.md
+++ b/src/formatting.style.md
@@ -25,7 +25,7 @@ func someLongFunctinName(
 
 ### Practical notes
 
-* We do not use `nimpretty` - as of writing (Nim 2.0), it is not stable enough for daily use
+* We do not use `nimpretty` - as of writing (Nim 2.2), it is not stable enough for daily use
   * Use [nph](./formatting.md) instead!
 * We do not make use of Nim's "flexible" identifier names - all uses of an identifier should match the declaration in capitalization and underscores
     * Enable `--styleCheck:usages` and, where feasible, `--styleCheck:error`


### PR DESCRIPTION
`nimpretty` still regularly corrupts ASTs and doesn't see regular maintenance.

ORC still has showstopping bugs as of 2.2.8.